### PR TITLE
Fix regexp of auto-mode-alist

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -330,7 +330,7 @@ Uses prefix (as PREFIX) to choose where to display it:
              (message "Making completion list...%s" "done")))))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.(plantuml|pum|plantuml|plu)$" . plantuml-mode))
+(add-to-list 'auto-mode-alist '("\\.(plantuml\\|pum\\|plantuml\\|plu)\\'" . plantuml-mode))
 
 ;;;###autoload
 (define-derived-mode plantuml-mode prog-mode "plantuml"


### PR DESCRIPTION
And use "\'" end of string anchor instead of "$".