### PR TITLE
Fix the syntax table to allow single-line comments.

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -84,8 +84,8 @@
 ;;; syntax table
 (defvar plantuml-mode-syntax-table
   (let ((synTable (make-syntax-table)))
-    (modify-syntax-entry ?\/  ". 41"    synTable)
-    (modify-syntax-entry ?'   "! 23b"    synTable)
+    (modify-syntax-entry ?\/  ". 14c"   synTable)
+    (modify-syntax-entry ?'   "< 23"    synTable)
     (modify-syntax-entry ?\n  ">"       synTable)
     (modify-syntax-entry ?\r  ">"       synTable)
     (modify-syntax-entry ?!   "w"       synTable)


### PR DESCRIPTION
The handling of single-line comments is quite broken at the moment, as the single quote is not declared as a comment-starter.

Before:
![before](https://cloud.githubusercontent.com/assets/822900/19454178/65940f80-94b8-11e6-9922-8ad320999dcd.png)

After this change:
![after](https://cloud.githubusercontent.com/assets/822900/19454211/868080de-94b8-11e6-9e63-1ffbd76193b3.png)
