### PR TITLE
Fixed regexp match pattern to truely match suffixes .plantuml .pum .plu.

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -349,7 +349,7 @@ Uses prefix (as PREFIX) to choose where to display it:
              (message "Making completion list...%s" "done")))))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.(plantuml\\|pum\\|plantuml\\|plu)\\'" . plantuml-mode))
+(add-to-list 'auto-mode-alist '("\\.\\(plantuml\\|pum\\|plu\\)\\'" . plantuml-mode))
 
 ;;;###autoload
 (define-derived-mode plantuml-mode prog-mode "plantuml"


### PR DESCRIPTION
current regexp for mode activation seems to match plantuml and pum in anywhere in file name.  For example, plantuml-mode.el loads plantuml-mode, instead of emacs-lisp-mode... 