### PR TITLE
Removed shell-quote-argument for Windows native Emacs to load jar fil…

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -220,7 +220,7 @@ default output type for new buffers."
   `(start-process "PLANTUML" ,buf
                   plantuml-java-command
                   ,@plantuml-java-args
-                  (shell-quote-argument plantuml-jar-path)
+                  plantuml-jar-path
                   (plantuml-output-type-opt) "-p"))
 
 (defun plantuml-preview-string (prefix string)


### PR DESCRIPTION
…e properly.

shell-quote-argument is preventing native windows Emacs to find jar file. Since start-process is used, it would not need shell quote - should work in Linux as well, but not tested, please test before pull commit.

The original issue was that I was getting

```
error in process sentinel: if: PLANTUML Preview failed: exited abnormally with code 1
error in process sentinel: PLANTUML Preview failed: exited abnormally with code 1
```

In `*Messages*` and
`Command is java -jar "c:/Users/tm/AppData/Roaming/.emacs.d/elisp/plantuml.jar"`
In `*PlantUML Messages*`

cygwin Emacs will need another #40 call-process patch to work properly in my environment. Also maybe which version of Java install might make things different.
