### PR TITLE
Add plantuml-preview-current-block

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -278,6 +278,18 @@ Uses prefix (as PREFIX) to choose where to display it:
                                        (region-beginning) (region-end))
                                       "\n@enduml")))
 
+(defun plantuml-preview-current-block (prefix)
+  "Preview diagram from the PlantUML sources from the previous @startuml to the next @enduml.
+Uses prefix (as PREFIX) to choose where to display it:
+- 4  (when prefixing the command with C-u) -> new window
+- 16 (when prefixing the command with C-u C-u) -> new frame.
+- else -> new buffer"
+  (interactive "p")
+  (save-restriction
+    (narrow-to-region
+     (search-backward "@startuml") (search-forward "@enduml"))
+    (plantuml-preview-buffer prefix)))
+
 (defun plantuml-preview (prefix)
   "Preview diagram from the PlantUML sources.
 Uses the current region if one is active, or the entire buffer otherwise.


### PR DESCRIPTION
Add a function that allows to preview the current block.
The current block is defined to be the region beginning
at previous "@startuml" and ending at "@enduml".
The prefix argument is handled according to the existing
preview functions.

This becomes handy when writing diagrams in a document
with multiple plantuml blocks.

In a future step the function could be extended to preview 
the diagram of the current page:
- @startuml to @enduml
- @startuml to next newpage
- previous newpage to next newpage
- previous newpage to @enduml
