### PR TITLE
Parenthesis around opt regexp should be escaped here

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -349,7 +349,7 @@ Uses prefix (as PREFIX) to choose where to display it:
              (message "Making completion list...%s" "done")))))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.(plantuml\\|pum\\|plantuml\\|plu)\\'" . plantuml-mode))
+(add-to-list 'auto-mode-alist '("\\.\\(plantuml\\|pum\\|plu\\)\\'" . plantuml-mode))
 
 ;;;###autoload
 (define-derived-mode plantuml-mode prog-mode "plantuml"


### PR DESCRIPTION
- Former regexp matches any string that contains `.(plantuml` or `pum`
  or `plantuml` or `plu` (e.g. `plantuml-mode.el` itself and any file
  that contain `pum` in its name)