### PR TITLE
Unset _JAVA_OPTIONS env variable on Travis to suppress warning from JVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 env:
   - EVM_EMACS=emacs-25.1-travis
 before_install:
+  - unset _JAVA_OPTIONS
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - evm install $EVM_EMACS --use --skip
   - cask


### PR DESCRIPTION
cf. https://github.com/travis-ci/travis-ci/issues/8408

Cherry-picked from #63 