### PR TITLE
Add autoindent support

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -393,7 +393,7 @@ Uses prefix (as PREFIX) to choose where to display it:
 
       (if (= -2 relative-depth)
           0
-        (+ 2 (current-indentation))))))
+        (+ tab-width (current-indentation))))))
 
 (defun plantuml-indent-line ()
   (interactive)
@@ -403,7 +403,7 @@ Uses prefix (as PREFIX) to choose where to display it:
         (indent-line-to 0)
       (let ((offset (plantuml-current-block-indentation)))
         (when (looking-at plantuml-indent-regexp-end)
-          (setq offset (max (- offset 2) 0)))
+          (setq offset (max (- offset tab-width) 0)))
         (indent-line-to offset)))))
 
 

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -323,6 +323,8 @@ Uses prefix (as PREFIX) to choose where to display it:
     (defvar plantuml-keywords-regexp (concat "^\\s *" (regexp-opt plantuml-keywords 'words)  "\\|\\(<\\|<|\\|\\*\\|o\\)\\(\\.+\\|-+\\)\\|\\(\\.+\\|-+\\)\\(>\\||>\\|\\*\\|o\\)\\|\\.\\{2,\\}\\|-\\{2,\\}"))
     (defvar plantuml-builtins-regexp (regexp-opt plantuml-builtins 'words))
     (defvar plantuml-preprocessors-regexp (concat "^\\s *" (regexp-opt plantuml-preprocessors 'words)))
+    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\\|alt\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\)\s+.*{\\)")
+    (defvar plantuml-indent-regexp-end "^[ \t]*\\(endif\\|else\\|end\\|end\s+note\\|.*}\\)")
 
     (setq plantuml-font-lock-keywords
           `(
@@ -375,9 +377,7 @@ Uses prefix (as PREFIX) to choose where to display it:
 
 
 ;; indentation
-(defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\\|alt\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\)\s+.*{\\)")
 
-(defvar plantuml-indent-regexp-end "^[ \t]*\\(endif\\|else\\|end\\|end\s+note\\|.*}\\)")
 
 (defun plantuml-current-block-indentation ()
   (save-excursion

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -373,6 +373,40 @@ Uses prefix (as PREFIX) to choose where to display it:
                 (all-completions meat plantuml-kwdList)))
              (message "Making completion list...%s" "done")))))
 
+
+;; indentation
+(defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\\|alt\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\)\s+.*{\\)")
+
+(defvar plantuml-indent-regexp-end "^[ \t]*\\(endif\\|else\\|end\\|end\s+note\\|.*}\\)")
+
+(defun plantuml-current-block-indentation ()
+  (save-excursion
+    (let ((relative-depth 0))
+      (while (>= relative-depth 0)
+        ;; (message (concat "got: " (number-to-string relative-depth)))
+        (forward-line -1)
+        (if (bobp)
+            (setq relative-depth -2))   ;end fast
+        (if (looking-at plantuml-indent-regexp-end)
+            (setq relative-depth (1+ relative-depth)))
+        (if (looking-at plantuml-indent-regexp-start)
+            (setq relative-depth (1- relative-depth))))
+
+      (if (= -2 relative-depth)
+          0
+        (+ 2 (current-indentation))))))
+
+(defun plantuml-indent-line ()
+  (interactive)
+  (beginning-of-line)
+  (if (bobp)
+      (indent-line-to 0)
+    (let ((offset (plantuml-current-block-indentation)))
+      (when (looking-at plantuml-indent-regexp-end)
+        (setq offset (max (- offset 2) 0)))
+      (indent-line-to offset))))
+
+
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.\\(plantuml\\|pum\\|plu\\)\\'" . plantuml-mode))
 
@@ -389,6 +423,7 @@ Shortcuts             Command Name
   (set (make-local-variable 'comment-end) "'/")
   (set (make-local-variable 'comment-multi-line) t)
   (set (make-local-variable 'comment-style) 'extra-line)
+  (set (make-local-variable 'indent-line-function) 'plantuml-indent-line)
   (setq font-lock-defaults '((plantuml-font-lock-keywords) nil t)))
 
 (defun plantuml-deprecation-warning ()

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -383,7 +383,6 @@ Uses prefix (as PREFIX) to choose where to display it:
   (save-excursion
     (let ((relative-depth 0))
       (while (>= relative-depth 0)
-        ;; (message (concat "got: " (number-to-string relative-depth)))
         (forward-line -1)
         (if (bobp)
             (setq relative-depth -2))   ;end fast

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -397,13 +397,14 @@ Uses prefix (as PREFIX) to choose where to display it:
 
 (defun plantuml-indent-line ()
   (interactive)
-  (beginning-of-line)
-  (if (bobp)
-      (indent-line-to 0)
-    (let ((offset (plantuml-current-block-indentation)))
-      (when (looking-at plantuml-indent-regexp-end)
-        (setq offset (max (- offset 2) 0)))
-      (indent-line-to offset))))
+  (save-excursion
+    (beginning-of-line)
+    (if (bobp)
+        (indent-line-to 0)
+      (let ((offset (plantuml-current-block-indentation)))
+        (when (looking-at plantuml-indent-regexp-end)
+          (setq offset (max (- offset 2) 0)))
+        (indent-line-to offset)))))
 
 
 ;;;###autoload

--- a/test/plantuml-indentation-test.el
+++ b/test/plantuml-indentation-test.el
@@ -1,0 +1,167 @@
+;;; plantuml-mode-indentation-test.el --- PlantUML Mode indentation tests   -*- lexical-binding: t; -*-
+
+;; Author: Raymond Huang (rymndhng)
+;; Maintainer: Carlo Sciolla (skuro)
+;; URL: https://github.com/skuro/plantuml-mode
+
+;;; Commentary:
+
+;; Test setup is inspired/taken from clojure-mode-indentation-tests
+
+;;; Code:
+
+;; This is taken from https://github.com/clojure-emacs/clojure-mode/blob/master/test/clojure-mode-indentation-test.el
+(defmacro check-indentation (description before after &optional var-bindings)
+  "Declare an ert test for indentation behaviour.
+The test will check that the swift indentation command changes the buffer
+from one state to another.  It will also test that point is moved to an
+expected position.
+DESCRIPTION is a symbol describing the test.
+BEFORE is the buffer string before indenting, where a pipe (|) represents
+point.
+AFTER is the expected buffer string after indenting, where a pipe (|)
+represents the expected position of point.
+VAR-BINDINGS is an optional let-bindings list.  It can be used to set the
+values of customisable variables."
+  (declare (indent 1))
+  (let ((fname (intern (format "indentation/%s" description))))
+    `(ert-deftest ,fname ()
+       (let* ((after ,after)
+              (clojure-indent-style :always-align)
+              (expected-cursor-pos (1+ (s-index-of "|" after)))
+              (expected-state (delete ?| after))
+              ,@var-bindings)
+         (with-temp-buffer
+           (insert ,before)
+           (goto-char (point-min))
+           (search-forward "|")
+           (delete-char -1)
+           (plantuml-mode)
+           (indent-according-to-mode)
+
+           (should (equal expected-state (buffer-string)))
+           (should (equal expected-cursor-pos (point))))))))
+
+(check-indentation toplevel-relationship
+  "|Nobody -> [APIGateway]"
+  "|Nobody -> [APIGateway]")
+
+(check-indentation package-block
+  "package APackage {
+|A -> B
+}" "package APackage {
+  |A -> B
+}")
+
+(check-indentation nested-package
+  "package APackage {
+|package AnotherPackage {
+}
+}"
+  "package APackage {
+  |package AnotherPackage {
+}
+}")
+
+(check-indentation empty-package
+  "|package Foo {}"
+  "|package Foo {}")
+
+(check-indentation relative-indent
+  "package APackage {
+database Foo
+|A --> B
+}
+}"
+  "package APackage {
+database Foo
+  |A --> B
+}
+}"
+  )
+
+(check-indentation note-as
+  "note as N1
+|This is a note
+end note"
+  "note as N1
+  |This is a note
+end note"
+  )
+
+(check-indentation note-of
+  "note right of Foo
+|This is a note
+end note"
+  "note right of Foo
+  |This is a note
+end note"
+  )
+
+(check-indentation alt
+  "alt choice 1
+|A -> B
+end
+"
+  "alt choice 1
+  |A -> B
+end
+")
+
+(check-indentation alt-end
+  "alt choice 1
+  A -> B
+|end
+"
+  "alt choice 1
+  A -> B
+|end
+")
+
+(check-indentation alt-else
+  "alt choice 1
+|else
+end
+"
+  "alt choice 1
+|else
+end
+")
+
+(check-indentation alt-else-body
+  "alt choice 1
+else
+|A -> B
+end
+"
+  "alt choice 1
+else
+  |A -> B
+end
+")
+
+(check-indentation alt-else-end
+  "alt choice 1
+else
+|end
+"
+  "alt choice 1
+else
+|end
+")
+
+(check-indentation alt-else-body
+  "alt choice 1
+else
+|A -> B
+end
+"
+  "alt choice 1
+else
+  |A -> B
+end
+")
+
+(provide 'plantuml-indentation-test)
+
+;;; plantuml-mode-preview-test.el ends here

--- a/test/plantuml-indentation-test.el
+++ b/test/plantuml-indentation-test.el
@@ -27,7 +27,6 @@ values of customisable variables."
   (let ((fname (intern (format "indentation/%s" description))))
     `(ert-deftest ,fname ()
        (let* ((after ,after)
-              (clojure-indent-style :always-align)
               (expected-cursor-pos (1+ (s-index-of "|" after)))
               (expected-state (delete ?| after))
               ,@var-bindings)

--- a/test/resources/unindented.plantuml
+++ b/test/resources/unindented.plantuml
@@ -1,0 +1,70 @@
+/' This is a manual test for you to test different use-cases '/
+Nobody -> [APIGateway]
+
+package APackage {
+A -> B
+B -> A
+}
+
+package "APP Stack" {
+[APIGateway] --> [Lambda]
+}
+
+package haha {}
+
+package "Streams Stack" {
+database Kinesis
+[Lambda] --> Kinesis
+}
+
+package foo {
+package bar {
+foo --> bar
+}
+
+package bar {
+foo --> bar
+}
+
+}
+
+
+package "Roles And Policies" {
+[Lambda] --> [IAM Roles]
+[APIGateway] --> [IAM Roles]
+}
+
+package "SharedResources" {
+[Lambda] ----> [LambdaCodeBucket]
+
+note as N1
+This belongs to a separate set
+of resources we should clean up
+separately.
+end note
+}
+
+note right of Lambda
+This thing is end of life
+end note
+
+note left of Nobody
+There is no traffic coming
+into the service.
+end note
+
+
+@startuml
+
+participant API
+participant Instance
+
+alt deploy success
+Instance -> API: Deploy successful
+else deploy failure
+Instance -> API: Deploy failed
+else deploy timeout
+Instance -> API: Deploy failed
+end
+
+@enduml


### PR DESCRIPTION
Addresses #28 

I took the suggestion from the comments and worked this from https://github.com/skuro/plantuml-mode/issues/28#issuecomment-276821796.

- simplified implementation (I think)
- I tweaked the regex patterns to support additional syntax such as `alt` and `note of`. 
- I added tests by taking ideas from clojure-mode's indent test

NOTE: I'm a emacs-lisp library noob and need guidance on how to clean this up. 