### PR TITLE
Rsch/indentation/fix and enhance

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -343,7 +343,7 @@ Uses prefix (as PREFIX) to choose where to display it:
     (defvar plantuml-keywords-regexp (concat "^\\s *" (regexp-opt plantuml-keywords 'words)  "\\|\\(<\\|<|\\|\\*\\|o\\)\\(\\.+\\|-+\\)\\|\\(\\.+\\|-+\\)\\(>\\||>\\|\\*\\|o\\)\\|\\.\\{2,\\}\\|-\\{2,\\}"))
     (defvar plantuml-builtins-regexp (regexp-opt plantuml-builtins 'words))
     (defvar plantuml-preprocessors-regexp (concat "^\\s *" (regexp-opt plantuml-preprocessors 'words)))
-    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\\|loop\s+.*\\|group\s+.*\\|par\s+\\|opt\s+.*\\|alt\s+.*\\|else\s+.*\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\)\s+.*{\\|activate\s+.*\\)")
+    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\s+.*\\|loop\s+.*\\|group\s+.*\\|par\s+\\|opt\s+.*\\|alt\s+.*\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\)\s+.*{\\|activate\s+.*\\)")
     (defvar plantuml-indent-regexp-end "^[ \t]*\\(endif\\|else\\|end\\|end\s+note\\|.*}\\|deactivate\s+.*\\)")
 
     (setq plantuml-font-lock-keywords

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -343,7 +343,7 @@ Uses prefix (as PREFIX) to choose where to display it:
     (defvar plantuml-keywords-regexp (concat "^\\s *" (regexp-opt plantuml-keywords 'words)  "\\|\\(<\\|<|\\|\\*\\|o\\)\\(\\.+\\|-+\\)\\|\\(\\.+\\|-+\\)\\(>\\||>\\|\\*\\|o\\)\\|\\.\\{2,\\}\\|-\\{2,\\}"))
     (defvar plantuml-builtins-regexp (regexp-opt plantuml-builtins 'words))
     (defvar plantuml-preprocessors-regexp (concat "^\\s *" (regexp-opt plantuml-preprocessors 'words)))
-    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\s+.*\\|loop\s+.*\\|group\s+.*\\|par\s+\\|opt\s+.*\\|alt\s+.*\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\)\s+.*{\\|activate\s+.+\\)")
+    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\s+.*\\|loop\s+.*\\|group\s+.*\\|par\s*$\\|opt\s+.*\\|alt\s+.*\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\|database\\)\s+.*{\\|activate\s+.+\\)")
     (defvar plantuml-indent-regexp-end "^[ \t]*\\(endif\\|else\\|end\\|end\s+note\\|.*}\\|deactivate\s+.+\\)")
 
     (setq plantuml-font-lock-keywords

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -343,8 +343,8 @@ Uses prefix (as PREFIX) to choose where to display it:
     (defvar plantuml-keywords-regexp (concat "^\\s *" (regexp-opt plantuml-keywords 'words)  "\\|\\(<\\|<|\\|\\*\\|o\\)\\(\\.+\\|-+\\)\\|\\(\\.+\\|-+\\)\\(>\\||>\\|\\*\\|o\\)\\|\\.\\{2,\\}\\|-\\{2,\\}"))
     (defvar plantuml-builtins-regexp (regexp-opt plantuml-builtins 'words))
     (defvar plantuml-preprocessors-regexp (concat "^\\s *" (regexp-opt plantuml-preprocessors 'words)))
-    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\\|alt\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\)\s+.*{\\)")
-    (defvar plantuml-indent-regexp-end "^[ \t]*\\(endif\\|else\\|end\\|end\s+note\\|.*}\\)")
+    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\\|loop\s+.*\\|group\s+.*\\|par\s+\\|opt\s+.*\\|alt\s+.*\\|else\s+.*\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:buttom\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:class\\|enum\\|package\\)\s+.*{\\|activate\s+.*\\)")
+    (defvar plantuml-indent-regexp-end "^[ \t]*\\(endif\\|else\\|end\\|end\s+note\\|.*}\\|deactivate\s+.*\\)")
 
     (setq plantuml-font-lock-keywords
           `(
@@ -409,8 +409,7 @@ Uses prefix (as PREFIX) to choose where to display it:
           (bob-visited? nil))
       (beginning-of-line)
       (forward-line -1)
-      (while (and (>= relative-depth 0)
-                  (not bob-visited?))
+      (while (not bob-visited?)
         (if (bobp)
             (setq bob-visited? t))
         (if (looking-at plantuml-indent-regexp-end)

--- a/test/plantuml-indentation-test.el
+++ b/test/plantuml-indentation-test.el
@@ -1,4 +1,4 @@
-;;; plantuml-mode-indentation-test.el --- PlantUML Mode indentation tests   -*- lexical-binding: t; -*-
+;;; plantuml-indentation-test.el --- PlantUML Mode indentation tests   -*- lexical-binding: t; -*-
 
 ;; Author: Raymond Huang (rymndhng)
 ;; Maintainer: Carlo Sciolla (skuro)
@@ -10,47 +10,142 @@
 
 ;;; Code:
 
-(defun add-text-and-position-cursor (txt)
-  "Add TXT into the buffer, move cursor to the position of the marker | and delete the marker."
+(defun plantuml-test-add-text-and-position-cursor (txt)
+  "Test helper for `plantuml-mode' tests.
+Add TXT into the buffer, move cursor to the position of the marker
+?| and delete the marker."
   (insert txt)
   (goto-char (point-min))
   (search-forward "|")
   (delete-char -1))
 
-(defun assert-block-depth (expected txt)
-  "Assert the EXPECTED indentation level for the given TXT."
+(defun plantuml-test-assert-block-depth (expected txt)
+  "Test helper for `plantuml-mode' tests.
+Assert the EXPECTED indentation level for the given TXT."
   (with-temp-buffer
-    (add-text-and-position-cursor txt)
+    (plantuml-test-add-text-and-position-cursor txt)
     (let ((actual (plantuml-current-block-depth)))
       (should (equal expected actual)))))
 
-(ert-deftest test-plantuml-current-block-depth ()
+(ert-deftest plantuml-test-current-block-depth_bob ()
+  "Test `plantuml-current-block-depth' level 0 at beginning of buffer."
   (setq-local plantuml-jar-path plantuml-test-jar-path)
   (plantuml-init-once)
 
-  (assert-block-depth 0 "
-A |-> B")
+  (plantuml-test-assert-block-depth 0 "|
+activate p1
+  activate p2
+    foo
+  deactivate p2
+deactivate p1
+")
+  )
 
-  (assert-block-depth 0 "
-pac|kage Foo {
-A -> B
-}")
+(ert-deftest plantuml-test-current-block-depth_0 ()
+  "Test `plantuml-current-block-depth' level 0 at beginning of first line."
+  (setq-local plantuml-jar-path plantuml-test-jar-path)
+  (plantuml-init-once)
 
-  (assert-block-depth 1 "
-package APackage {
-|A -> B
-}")
+  (plantuml-test-assert-block-depth 0 "
+|activate p1
+  activate p2
+    foo
+  deactivate p2
+deactivate p1
+")
+  )
 
+(ert-deftest plantuml-test-current-block-depth_1 ()
+  "Test `plantuml-current-block-depth' level 0 at middle of first line."
+  (setq-local plantuml-jar-path plantuml-test-jar-path)
+  (plantuml-init-once)
 
-  (assert-block-depth 1 "
-alt choice 1
-|A -> B
-end
-"))
+  (plantuml-test-assert-block-depth 0 "
+acti|vate p1
+  activate p2
+    foo
+  deactivate p2
+deactivate p1
+")
+  )
+
+(ert-deftest plantuml-test-current-block-depth_2 ()
+  "Test `plantuml-current-block-depth' level 0 at end of first line"
+  (setq-local plantuml-jar-path plantuml-test-jar-path)
+  (plantuml-init-once)
+
+  (plantuml-test-assert-block-depth 0 "
+activate p1|
+  activate p2
+    foo
+  deactivate p2
+deactivate p1
+")
+  )
+
+(ert-deftest plantuml-test-current-block-depth_3 ()
+  "Test `plantuml-current-block-depth' level 1 at beginning of 2nd line."
+
+  (plantuml-test-assert-block-depth 1 "
+activate p1
+  |activate p2
+    foo
+  deactivate p2
+deactivate p1
+")
+  )
+
+(ert-deftest plantuml-test-current-block-depth_4 ()
+  "Test `plantuml-current-block-depth' level 2 at beginning of 3rd line."
+
+  (plantuml-test-assert-block-depth 2 "
+activate p1
+  activate p2
+    |foo
+  deactivate p2
+deactivate p1
+")
+  )
+
+(ert-deftest plantuml-test-current-block-depth_5 ()
+  "Test `plantuml-current-block-depth' level 1 at beginning of 4th line."
+
+  (plantuml-test-assert-block-depth 1 "
+activate p1
+  activate p2
+    foo
+  |deactivate p2
+deactivate p1
+")
+  )
+
+(ert-deftest plantuml-test-current-block-depth_6 ()
+  "Test `plantuml-current-block-depth' level 0 at beginning of 5th line."
+
+  (plantuml-test-assert-block-depth 0 "
+activate p1
+  activate p2
+    foo
+  deactivate p2
+|deactivate p1
+")
+  )
+
+(ert-deftest plantuml-test-current-block-depth_eob ()
+  "Test `plantuml-current-block-depth' level 0 at end of buffer."
+
+  (plantuml-test-assert-block-depth 0 "
+activate p1
+  activate p2
+    foo
+  deactivate p2
+deactivate p1
+|")
+  )
 
 ;; This is taken from https://github.com/clojure-emacs/clojure-mode/blob/master/test/clojure-mode-indentation-test.el
-(defmacro check-indentation (description before after &optional var-bindings)
-  "Declare an ert test for indentation behaviour.
+(defmacro plantuml-test-line-indentation (description before after &optional var-bindings)
+  "Declare an ert test for line indentation behaviour.
 The test will check that the swift indentation command changes the buffer
 from one state to another.  It will also test that point is moved to an
 expected position.
@@ -61,8 +156,9 @@ AFTER is the expected buffer string after indenting, where a pipe (|)
 represents the expected position of point.
 VAR-BINDINGS is an optional let-bindings list.  It can be used to set the
 values of customisable variables."
+
   (declare (indent 1))
-  (let ((fname (intern (format "indentation/%s" description))))
+  (let ((fname (intern (format "plantuml-test-line-indentation/%s" description))))
     `(ert-deftest ,fname ()
        (let* ((after ,after)
               (expected-cursor-pos (1+ (s-index-of "|" after)))
@@ -74,7 +170,7 @@ values of customisable variables."
            (setq-local plantuml-jar-path plantuml-test-jar-path)
            (plantuml-init-once)
 
-           (add-text-and-position-cursor ,before)
+           (plantuml-test-add-text-and-position-cursor ,before)
            (plantuml-mode)
 
            ;; use 2 spaces instead of one tab for indentation
@@ -85,19 +181,19 @@ values of customisable variables."
            (should (equal expected-state (buffer-string)))
            (should (equal expected-cursor-pos (point))))))))
 
-(check-indentation toplevel-relationship
+(plantuml-test-line-indentation toplevel-relationship
   "|Nobody -> [APIGateway]"
   "|Nobody -> [APIGateway]")
 
-(check-indentation package-block
-                   "package APackage {
+(plantuml-test-line-indentation package-block
+  "package APackage {
 |A -> B
 }"
-                   "package APackage {
+  "package APackage {
   |A -> B
 }")
 
-(check-indentation nested-package
+(plantuml-test-line-indentation nested-package
   "package APackage {
 |package AnotherPackage {
 }
@@ -107,11 +203,11 @@ values of customisable variables."
 }
 }")
 
-(check-indentation empty-package
+(plantuml-test-line-indentation empty-package
   "|package Foo {}"
   "|package Foo {}")
 
-(check-indentation relative-indent
+(plantuml-test-line-indentation relative-indent
   "package APackage {
 database Foo
 |A --> B
@@ -124,7 +220,7 @@ database Foo
 }"
   )
 
-(check-indentation note-as
+(plantuml-test-line-indentation note-as
   "note as N1
 |This is a note
 end note"
@@ -133,7 +229,7 @@ end note"
 end note"
   )
 
-(check-indentation note-of
+(plantuml-test-line-indentation note-of
   "note right of Foo
 |This is a note
 end note"
@@ -142,75 +238,169 @@ end note"
 end note"
   )
 
-(check-indentation alt
-  "alt choice 1
+(plantuml-test-line-indentation alt
+                                      "alt choice 1
 |A -> B
 end
 "
-  "alt choice 1
+                                      "alt choice 1
   |A -> B
 end
 ")
 
-(check-indentation alt-end
-  "alt choice 1
+(plantuml-test-line-indentation alt-end
+                                "alt choice 1
   A -> B
 |end
 "
-  "alt choice 1
+                                "alt choice 1
   A -> B
 |end
 ")
 
-(check-indentation alt-else
-  "alt choice 1
+(plantuml-test-line-indentation alt-else
+                                "alt choice 1
 |else
 end
 "
-  "alt choice 1
+                                "alt choice 1
 |else
 end
 ")
 
-(check-indentation alt-else-body
-  "alt choice 1
+(plantuml-test-line-indentation alt-else-body
+                                "alt choice 1
 else
 |A -> B
 end
 "
-  "alt choice 1
+                                "alt choice 1
 else
   |A -> B
 end
 ")
 
-(check-indentation alt-else-end
-  "alt choice 1
+(plantuml-test-line-indentation alt-else-end
+                                "alt choice 1
 else
 |end
 "
-  "alt choice 1
+                                "alt choice 1
 else
 |end
 ")
 
-(check-indentation opt
-  "opt have fun
+(plantuml-test-line-indentation opt-body
+                                "opt have fun
 |some text
 end"
-  "opt have fun
+                                "opt have fun
   |some text
 end")
 
-(check-indentation activate-deactivate
-  "activate participant_1
-|participant_1 -> participant_2 : f()
-deactivate participant_1"
-  "activate participant_1
-  |participant_1 -> participant_2 : f()
-deactivate participant_1")
+(plantuml-test-line-indentation opt-end
+                                "opt have fun
+  some text
+|end"
+                                "opt have fun
+  some text
+|end")
 
+(plantuml-test-line-indentation activate-activate
+                                "
+|activate participant_1
+"
+                                "
+|activate participant_1
+")
+
+(plantuml-test-line-indentation activate-body
+                                "
+activate participant_1
+|participant_1 -> participant_2 : f()
+"
+
+                                "
+activate participant_1
+  |participant_1 -> participant_2 : f()
+")
+
+(plantuml-test-line-indentation activate-deactivate
+                                "
+activate participant_1
+  participant_1 -> participant_2 : f()
+|deactivate participant_1"
+
+                                "
+activate participant_1
+  participant_1 -> participant_2 : f()
+|deactivate participant_1")
+
+(plantuml-test-line-indentation activate-deactivate-2
+                                "
+               activate participant_1
+participant_1 -> participant_2 : f()
+            |deactivate participant_1"
+                                "
+               activate participant_1
+participant_1 -> participant_2 : f()
+|deactivate participant_1")
+
+(plantuml-test-line-indentation activate-deactivate-3
+                                "
+               activate participant_1
+participant_1 -> participant_2 : f()
+            deactivate| participant_1"
+                                "
+               activate participant_1
+participant_1 -> participant_2 : f()
+deactivate| participant_1")
+
+(defun plantuml-test-indent-block (textblock)
+  "Test helper for `plantuml-mode' indentation tests.
+TEXTBLOCK will be inserted into a new temporary plantuml buffer. The
+whole text will be indented according to the mode. Then, the buffer
+contents is returned as a string."
+
+  (with-temp-buffer
+    ;; fix the JAR location prior to mode initialization
+    ;; for some reason, plantuml-mode disregards the setq-local
+    (setq-local plantuml-jar-path plantuml-test-jar-path)
+    (plantuml-init-once)
+
+    (insert textblock)
+    (goto-char (point-min))
+    (plantuml-mode)
+    ;; use 2 spaces instead of one tab for indentation
+    (setq-local indent-tabs-mode nil)
+    (setq-local tab-width 2)
+
+    (indent-region (point-min) (point-max))
+    (buffer-string)
+    ))
+
+(ert-deftest plantuml-test-block-indentation/activate-deactivate-unindented ()
+  "test"
+  (should (equal (plantuml-test-indent-block   "
+activate participant_1
+participant_1 -> participant_2 : f()
+deactivate participant_1")
+                 "
+activate participant_1
+  participant_1 -> participant_2 : f()
+deactivate participant_1")))
+
+(ert-deftest plantuml-test-block-indentation/activate-deactivate-malformed-indent ()
+  "test"
+  (should (equal (plantuml-test-indent-block   "
+               activate participant_1
+participant_1 -> participant_2 : f()
+            deactivate participant_1")
+                 "
+activate participant_1
+  participant_1 -> participant_2 : f()
+deactivate participant_1")))
 
 (provide 'plantuml-indentation-test)
 
-;;; plantuml-mode-preview-test.el ends here
+;;; plantuml-indentation-test.el ends here

--- a/test/plantuml-indentation-test.el
+++ b/test/plantuml-indentation-test.el
@@ -194,17 +194,22 @@ else
 |end
 ")
 
-(check-indentation alt-else-body
-  "alt choice 1
-else
-|A -> B
-end
-"
-  "alt choice 1
-else
-  |A -> B
-end
-")
+(check-indentation opt
+  "opt have fun
+|some text
+end"
+  "opt have fun
+  |some text
+end")
+
+(check-indentation activate-deactivate
+  "activate participant_1
+|participant_1 -> participant_2 : f()
+deactivate participant_1"
+  "activate participant_1
+  |participant_1 -> participant_2 : f()
+deactivate participant_1")
+
 
 (provide 'plantuml-indentation-test)
 


### PR DESCRIPTION
Please merge into master.
My original intention was to make activate/deactivate blocks known to indentation. When I started to write tests for it I faced more problems, so I diged into them and fixed them. That started much more changes. Nevertheless, I think the code for indentation is simpler and clearer now. Tests cover at least what was tested before and more.
Once you accepted my changes, I will continue to deliver more changes (missing tests, fix single line note indentation, …) but on different branches.
There is one minor thing: when running the tests we get some output on the console and I don't know how to prevent that:
“Indenting region…
Indenting region…done”