### PR TITLE
Save generated diagrams to file

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -334,6 +334,15 @@ Uses prefix (as PREFIX) to choose where to display it:
       (plantuml-preview-region prefix (region-beginning) (region-end))
     (plantuml-preview-buffer prefix)))
 
+(defun plantuml-save-to-file ()
+  (interactive)
+  (clipboard-kill-ring-save (point-min) (point-max))
+  (generate-new-buffer "untitled")
+  (switch-to-buffer "untitled")
+  (yank)
+  (save-buffer)
+)
+
 (defun plantuml-init-once ()
   "Ensure initialization only happens once."
   (unless plantuml-kwdList

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -335,6 +335,10 @@ Uses prefix (as PREFIX) to choose where to display it:
     (plantuml-preview-buffer prefix)))
 
 (defun plantuml-save-to-file ()
+  "Save the generated image to a file.
+This command will as for the path and filename to which the image
+should be saved. 
+This command should be executed from the *PLANTUML Preview* buffer only"
   (interactive)
   (clipboard-kill-ring-save (point-min) (point-max))
   (generate-new-buffer "untitled")


### PR DESCRIPTION
I have added a small function to save the generated image to a file. 
plantuml-save-to-file should be evoked when in the *Plantuml Preview* buffer.
This functions copies the contents of the preview buffer onto a new buffer and saves it. It asks for the path to which the file is to be saved.