### PR TITLE
Indent interface and entity declarations

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -342,7 +342,7 @@ Uses prefix (as PREFIX) to choose where to display it:
     (defvar plantuml-keywords-regexp (concat "^\\s *" (regexp-opt plantuml-keywords 'words)  "\\|\\(<\\|<|\\|\\*\\|o\\)\\(\\.+\\|-+\\)\\|\\(\\.+\\|-+\\)\\(>\\||>\\|\\*\\|o\\)\\|\\.\\{2,\\}\\|-\\{2,\\}"))
     (defvar plantuml-builtins-regexp (regexp-opt plantuml-builtins 'words))
     (defvar plantuml-preprocessors-regexp (concat "^\\s *" (regexp-opt plantuml-preprocessors 'words)))
-    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\s+.*\\|loop\s+.*\\|group\s+.*\\|par\s*$\\|opt\s+.*\\|alt\s+.*\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:button\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:\\(abstract \\)?class\\|enum\\|package\\|database\\|frame\\|cloud\\|folder\\)\s+.*{\\|activate\s+.+\\)")
+    (defvar plantuml-indent-regexp-start "^[ \t]*\\(\\(?:.*\\)?\s*\\(?:[<>.*a-z-|]+\\)?\s*\\(?:\\[[a-zA-Z]+\\]\\)?\s+if\s+.*\\|loop\s+.*\\|group\s+.*\\|par\s*$\\|opt\s+.*\\|alt\s+.*\\|else\\|note\s+over\\|note\sas\s.*\\|note\s+\\(\\(?:\\(?:button\\|left\\|right\\|top\\)\\)\\)\\(?:\s+of\\)?\\|\\(?:\\(abstract \\)?class\\|enum\\|entity\\|interface\\|package\\|database\\|frame\\|cloud\\|folder\\)\s+.*{\\|activate\s+.+\\)")
     (defvar plantuml-indent-regexp-end "^[ \t]*\\(endif\\|else\\|end\\|end\s+note\\|.*}\\|deactivate\s+.+\\)")
 
     (setq plantuml-font-lock-keywords


### PR DESCRIPTION
Previously `interface` and `entity` declarations wouldn't get their own indent blocks:

```plantuml
@startuml
package foo {
  interface Bar {
  baz
}
}
@enduml
```

This change adds them to the indent list:

```plantuml
@startuml
package foo {
  interface Bar {
    baz
  }
}
@enduml
```