### PR TITLE
“fix” for #62: Unable to change any colors

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -209,8 +209,8 @@
 (defvar plantuml-output-type
   (if (not (display-images-p))
       "utxt"
-    (cond ((image-type-available-p 'svg) "svg")
-          ((image-type-available-p 'png) "png")
+    (cond ((image-type-available-p 'png) "png")
+          ((image-type-available-p 'svg) "svg")
           (t "utxt")))
   "Specify the desired output type to use for generated diagrams.")
 
@@ -219,8 +219,8 @@
   (let* ((completion-ignore-case t)
          (available-types
           (append
-           (and (image-type-available-p 'svg) '("svg"))
            (and (image-type-available-p 'png) '("png"))
+           (and (image-type-available-p 'svg) '("svg"))
            '("utxt"))))
     (completing-read (format "Output type [%s]: " plantuml-output-type)
                      available-types


### PR DESCRIPTION
This is not really a fix as this problem is not a problem of
plantuml-mode!

The generated svg (generated by plantuml) is displayed by several svg
viewers with a transparent background. One of such viewers is
ImageMagick's display command (which is used by emacs if it is
present). On the other hand, most web-browsers show it on a coloured
background. The problem can be solved by plantuml such, that they
insert a \<rect width="100%" height="100%" fill="#A9A9A9"\/\> as first
child of the svg-element.

However, plantuml-mode can pass png as the default image type to
plantuml. In this case users of plantuml-mode will see the correct result.

Sorry, no tests! I don’t have a clue how to test the issue.