### PR TITLE
Rsch/own tab width

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -108,6 +108,11 @@
   :type '(repeat string)
   :group 'plantuml)
 
+(defcustom plantuml-tab-width tab-width
+  "The number of spaces used for indentation."
+  :type 'integer
+  :group 'plantuml)
+
 (defcustom plantuml-suppress-deprecation-warning t
   "To silence the deprecation warning when `puml-mode' is found upon loading."
   :type 'boolean
@@ -460,7 +465,7 @@ Restore point to same position in text of the line as before indentation."
   (let ((original-position-eol (- (line-end-position) (point))))
     (save-excursion
       (beginning-of-line)
-      (indent-line-to (* tab-width (plantuml-current-block-depth))))
+      (indent-line-to (* plantuml-tab-width (plantuml-current-block-depth))))
 
     ;; restore position in text of line
     (goto-char (- (line-end-position) original-position-eol))))

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -209,8 +209,8 @@
 (defvar plantuml-output-type
   (if (not (display-images-p))
       "utxt"
-    (cond ((image-type-available-p 'svg) "svg")
-          ((image-type-available-p 'png) "png")
+    (cond ((image-type-available-p 'png) "png")
+          ((image-type-available-p 'svg) "svg")
           (t "utxt")))
   "Specify the desired output type to use for generated diagrams.")
 
@@ -219,8 +219,8 @@
   (let* ((completion-ignore-case t)
          (available-types
           (append
-           (and (image-type-available-p 'svg) '("svg"))
            (and (image-type-available-p 'png) '("png"))
+           (and (image-type-available-p 'svg) '("svg"))
            '("utxt"))))
     (completing-read (format "Output type [%s]: " plantuml-output-type)
                      available-types

--- a/test/plantuml-indentation-basics-test.el
+++ b/test/plantuml-indentation-basics-test.el
@@ -166,7 +166,7 @@ the position of | in AFTER."
 
       ;; use 2 spaces instead of one tab for indentation
       (setq-local indent-tabs-mode nil)
-      (setq-local tab-width 2)
+      (setq-local plantuml-tab-width 2)
       (indent-according-to-mode)
 
       (should (equal expected-state (buffer-string)))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -61,7 +61,7 @@ Finally, the indented text in the buffer will be compared with AFTER."
     (plantuml-mode)
     ;; use 2 spaces instead of one tab for indentation
     (setq-local indent-tabs-mode nil)
-    (setq-local tab-width 2)
+    (setq-local plantuml-tab-width 2)
 
     (indent-region (point-min) (point-max))
     (should (equal (buffer-string) after))))


### PR DESCRIPTION

Default is still the global tab-width. For diagrams I usually like to
have a smaller indentation (2 spaces) than I use in programming (4
spaces).

Is tested implicitly, as the variable is setq-local in test prepartions.