### PR TITLE
Improving preview functionality. No buffer switch.

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -262,33 +262,28 @@ to choose where to display it:
 - 4  (when prefixing the command with C-u) -> new window
 - 16 (when prefixing the command with C-u C-u) -> new frame.
 - else -> new buffer"
-  (let ((b (get-buffer plantuml-preview-buffer)))
-    (when b
-      (kill-buffer b)))
-
   (let* ((imagep (and (display-images-p)
                       (plantuml-is-image-output-p)))
          (process-connection-type nil)
-         (buf (get-buffer-create plantuml-preview-buffer))
          (coding-system-for-read (and imagep 'binary))
          (coding-system-for-write (and imagep 'binary)))
 
-    (let ((ps (plantuml-start-process buf)))
-      (process-send-string ps string)
-      (process-send-eof ps)
-      (set-process-sentinel ps
-                            (lambda (_ps event)
-                              (unless (equal event "finished\n")
-                                (error "PLANTUML Preview failed: %s" event))
-                              (cond
-                               ((= prefix 16)
-                                (switch-to-buffer-other-frame plantuml-preview-buffer))
-                               ((= prefix 4)
-                                (switch-to-buffer-other-window plantuml-preview-buffer))
-                               (t (switch-to-buffer plantuml-preview-buffer)))
-                              (when imagep
-                                (image-mode)
-                                (set-buffer-multibyte t)))))))
+    (with-output-to-temp-buffer plantuml-preview-buffer
+      (let* ((buf (get-buffer-create plantuml-preview-buffer)) (ps (plantuml-start-process buf)))
+        (process-send-string ps string)
+        (process-send-eof ps)
+        (set-process-sentinel ps
+                              (lambda (_ps event)
+                                (unless (equal event "finished\n")
+                                  (error "PLANTUML Preview failed: %s" event))
+                                (cond
+                                 ((= prefix 16)
+                                  (switch-to-buffer-other-frame plantuml-preview-buffer))
+                                 ((= prefix 4)
+                                  (switch-to-buffer-other-window plantuml-preview-buffer)))
+                                (when imagep
+                                  (image-mode)
+                                  (set-buffer-multibyte t))))))))
 
 (defun plantuml-preview-buffer (prefix)
   "Preview diagram from the PlantUML sources in the current buffer.

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -262,26 +262,32 @@ to choose where to display it:
 - 4  (when prefixing the command with C-u) -> new window
 - 16 (when prefixing the command with C-u C-u) -> new frame.
 - else -> new buffer"
+  (let ((b (get-buffer plantuml-preview-buffer)))
+    (when b
+      (kill-buffer b)))
+
   (let* ((imagep (and (display-images-p)
                       (plantuml-is-image-output-p)))
          (process-connection-type nil)
+         (buf (get-buffer-create plantuml-preview-buffer))
          (coding-system-for-read (and imagep 'binary))
          (coding-system-for-write (and imagep 'binary)))
 
-    (with-output-to-temp-buffer plantuml-preview-buffer
-      (let* ((buf (get-buffer-create plantuml-preview-buffer)) (ps (plantuml-start-process buf)))
-        (process-send-string ps string)
-        (process-send-eof ps)
-        (set-process-sentinel ps
-                              (lambda (_ps event)
-                                (unless (equal event "finished\n")
-                                  (error "PLANTUML Preview failed: %s" event))
-                                (cond
-                                 ((= prefix 16)
-                                  (switch-to-buffer-other-frame plantuml-preview-buffer))
-                                 ((= prefix 4)
-                                  (switch-to-buffer-other-window plantuml-preview-buffer)))
-                                (when imagep
+    (let ((ps (plantuml-start-process buf)))
+      (process-send-string ps string)
+      (process-send-eof ps)
+      (set-process-sentinel ps
+                            (lambda (_ps event)
+                              (unless (equal event "finished\n")
+                                (error "PLANTUML Preview failed: %s" event))
+                              (cond
+                               ((= prefix 16)
+                                (switch-to-buffer-other-frame plantuml-preview-buffer))
+                               ((= prefix 4)
+                                (switch-to-buffer-other-window plantuml-preview-buffer))
+                               (t (display-buffer plantuml-preview-buffer)))
+                              (when imagep
+                                (with-current-buffer plantuml-preview-buffer
                                   (image-mode)
                                   (set-buffer-multibyte t))))))))
 


### PR DESCRIPTION
This an improvement to the preview functionality, where the buffer layout is retained when preview is requested.

**Current behaviour:**
The preview functionality switch the current active buffer with the preview buffer, which could be annoying when developing diagrams iteratively, as the user has to constantly switch back the buffers.

**New behaviour:**
Using `with-output-to-temp-buffer` functionality, the preview is created using a temp buffer that split the layout, and most importantly, it retains the layout if preview is requested again, so the user does not have to switch buffers all the time.
