### PR TITLE
CI downloads plantuml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@ default: &default-steps
   steps:
     - checkout
     - run:
+        # Note: this makes it hard to reproduce builds but easier to spot incompatibilities with
+        # newer PlantUML releases. Current trade off seems acceptable.
+        name: Download the latest PlantUML release
+        command: sh ./bin/download-plantuml.sh
+    - run:
         name: Update APT packages
         command: apt-get update
     - run:

--- a/bin/download-plantuml.sh
+++ b/bin/download-plantuml.sh
@@ -16,4 +16,5 @@ LATEST_VERSION="$(curl "${VERSIONS_URL}" | grep -oP) '(?<=<str name=\"v\">).*?(?
 DOWNLOAD_URL="https://search.maven.org/remotecontent?filepath=net/sourceforge/plantuml/plantuml/${LATEST_VERSION}/plantuml-${LATEST_VERSION}.jar"
 
 # finally, download the JAR file
-curl -o "${OUTPUT_PATH}" "${DOWNLOAD_URL}"
+echo "Downloading PlantUML v${LATEST_VERSION} into ${OUTPUT_PATH}"
+curl -so "${OUTPUT_PATH}" "${DOWNLOAD_URL}"

--- a/bin/download-plantuml.sh
+++ b/bin/download-plantuml.sh
@@ -10,11 +10,11 @@ OUTPUT_PATH="${CURRENT_PATH}/plantuml.jar"
 VERSIONS_URL='https://search.maven.org/solrsearch/select?q=g:net.sourceforge.plantuml+AND+a:plantuml&core=gav&start=0&rows=1&wt=xml'
 
 # Only match the contents of the version (name="v") XML tag
-LATEST_VERSION="$(curl "${VERSIONS_URL}" | grep -oP) '(?<=<str name=\"v\">).*?(?=</str>)'"
+LATEST_VERSION="$(curl -s "${VERSIONS_URL}" | grep -oP '(?<=<str name="v">).*(?=</str>)')"
 
 # Compose the download link
 DOWNLOAD_URL="https://search.maven.org/remotecontent?filepath=net/sourceforge/plantuml/plantuml/${LATEST_VERSION}/plantuml-${LATEST_VERSION}.jar"
 
 # finally, download the JAR file
 echo "Downloading PlantUML v${LATEST_VERSION} into ${OUTPUT_PATH}"
-curl -so "${OUTPUT_PATH}" "${DOWNLOAD_URL}"
+curl -so "${OUTPUT_PATH}" "${DOWNLOAD_URL}" 2>/dev/null

--- a/bin/download-plantuml.sh
+++ b/bin/download-plantuml.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Where the script is executed
+CURRENT_PATH="$(dirname "$(readlink -f "$0")")"
+
+# Where to download the file
+OUTPUT_PATH="${CURRENT_PATH}/plantuml.jar"
+
+# Retrieve the list of versions, in XML format, only one result (the latest)
+VERSIONS_URL='https://search.maven.org/solrsearch/select?q=g:net.sourceforge.plantuml+AND+a:plantuml&core=gav&start=0&rows=1&wt=xml'
+
+# Only match the contents of the version (name="v") XML tag
+LATEST_VERSION="$(curl "${VERSIONS_URL}" | grep -oP) '(?<=<str name=\"v\">).*?(?=</str>)'"
+
+# Compose the download link
+DOWNLOAD_URL="https://search.maven.org/remotecontent?filepath=net/sourceforge/plantuml/plantuml/${LATEST_VERSION}/plantuml-${LATEST_VERSION}.jar"
+
+# finally, download the JAR file
+curl -o "${OUTPUT_PATH}" "${DOWNLOAD_URL}"

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -37,6 +37,7 @@
 
 ;;; Change log:
 ;;
+;; version 1.2.10, 2019-04-03 Avoid messing with window layouts and buffers -- courtesy of https://github.com/wailo
 ;; version 1.2.9, Revamped indentation support, now working with a greater number of keywords
 ;; version 1.2.8, 2019-01-07 Support indentation for activate / deactivate blocks; allow customization of `plantuml-java-args'
 ;; version 1.2.7, 2018-08-15 Added support for indentation; Fixed the comiling error when installing with melpa


### PR DESCRIPTION
Fixes #73 

Now the latest version of PlantUML is downloaded as part of the CI script. This has two consequences:

## we always test against the latest and greatest PlantUML version. 
PlantUML evolves at a much higher pace than `plantuml-mode`. This allows for some sanity check of our code with the upstream project.

## builds are not reproducible
As a side effect of always downloading a (potentially) new PlantUML version, re-running the build for an old commit can lead to different outcomes. This is usually a big no-no but given the limited efforts currently spent on `plantuml-mode` I find it more convenient to immediately raise a flag if a new version of PlantUML causes issues.