### PR TITLE
Added capability to automatically download the PlantUML jar path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Also, to enable preview you need to tell `plantuml-mode` where to locate the Pla
     M-x customize-variable<RET>
     plantuml-jar-path<RET>
 
+You can also download the latest version of PlantUML straight into `plantuml-jar-path`:
+
+    M-x plantuml-download-jar<RET>
+
 # Features
 
 - Syntax highlight

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -183,7 +183,6 @@
                                     (first)
                                     (xml-node-children)
                                     (first))))
-              ;; (message (-filter (lambda (node) (string-equal "v" (xml-get-attribute node 'name))) strs))
               (message (concat "Downloading PlantUML v" version " into " plantuml-jar-path))
               (url-copy-file (format "https://search.maven.org/remotecontent?filepath=net/sourceforge/plantuml/plantuml/%s/plantuml-%s.jar" version version) plantuml-jar-path)
               (kill-buffer))


### PR DESCRIPTION
As an effort to ease the first user setup, a new function is added to download the latest
PlantUML JAR release into `plantuml-jar-path` from Maven central.