### PR TITLE
Add run mode EXECUTABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ As of `v1.3.0` support is added for switching execution mode. The following two 
 
 - `jar` (default) to run PlantUML as a local JAR file. This is the traditional system used by `plantuml-mode`
 - `server` (experimental) to let an instance of [`plantuml-server`](https://github.com/plantuml/plantuml-server) render the preview
+- `executable` to run PlantUML as a local executable file. This is useful if your package manager provides a executable for PlantUML.
 
 You can customize `plantuml-default-exec-mode` or run `plantuml-set-exec-mode` from a `plantuml-mode` buffer to switch modes.
 

--- a/test/plantuml-config-test.el
+++ b/test/plantuml-config-test.el
@@ -20,6 +20,8 @@
     (should (equal 'server plantuml-exec-mode))
     (plantuml-set-exec-mode "jar")
     (should (equal 'jar plantuml-exec-mode))
+    (plantuml-set-exec-mode "executable")
+    (should (equal 'executable plantuml-exec-mode))
 
     (setq plantuml-exec-mode orig-mode)))
 


### PR DESCRIPTION
This adds the run mode EXECUTABLE. With this mode is it possible to run PlantUML as a executable. This is useful if you for example install PlantUML via your distributions package manger.