### PR TITLE
Fix arguments for jar

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -375,7 +375,7 @@ Note that output type `txt' is promoted to `utxt' for better rendering."
            `(,@java-args
              ,(expand-file-name plantuml-jar-path)
              ,(plantuml-jar-output-type-opt plantuml-output-type)
-             ,@java-args
+             ,@plantuml-jar-args
              "-p"))))
 
 (defun plantuml-executable-start-process (buf)


### PR DESCRIPTION
The arguments for plantuml.jar seems wrong. (In my environment Japanese encoding goes wrong because of lack of "-charset UTF-8" option)

Here is a quick fix suggestion.