### PR TITLE
support for simple HEX encoding format

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -106,6 +106,9 @@
     keymap)
   "Keymap for plantuml-mode.")
 
+;; only simple HEX format for now. Old prefixes, e.g. -base64- and -hex- not supported
+(defvar plantuml-encoding-prefix "~h" "PLantUML encoding prefix.")
+
 (defcustom plantuml-java-command "java"
   "The java command used to execute PlantUML."
   :type 'string
@@ -422,12 +425,24 @@ Put the result into buffer BUF.  Window is selected according to PREFIX:
                               (error "PLANTUML Preview failed: %s" event))
                             (plantuml-update-preview-buffer prefix buf)))))
 
+(defun plantuml-hexlify (string)
+  "Encode the string STRING as HEX."
+  (mapconcat (lambda(s) (format "%02x" s)) (string-to-list string) ""))
+
+(defun plantuml-encode-data (string)
+  "Encode string STRING according to the `plantuml-server-encoding'."
+  ;; handle only simple HEX encoding
+  (plantuml-hexlify string)
+  ;;
+  ;; base64
+  ;;(let ((coding-system (or buffer-file-coding-system "utf8")))
+  ;;   (base64-encode-string (encode-coding-string string coding-system) t)))
+  )
+
 (defun plantuml-server-encode-url (string)
   "Encode the string STRING into a URL suitable for PlantUML server interactions."
-  (let* ((coding-system (or buffer-file-coding-system
-                            "utf8"))
-         (encoded-string (base64-encode-string (encode-coding-string string coding-system) t)))
-    (concat plantuml-server-url "/" plantuml-output-type "/-base64-" encoded-string)))
+  (concat plantuml-server-url "/" plantuml-output-type  "/" plantuml-encoding-prefix (plantuml-encode-data string)))
+
 
 (defun plantuml-server-preview-string (prefix string buf)
   "Preview the diagram from STRING as rendered by the PlantUML server.


### PR DESCRIPTION
HEX encoding format instead of base64

reasons:
it seems that developers of plantuml introduced some changes in encoding. plantuml-mode stopped working with base64 encoding. 

Links:
1. updated documentation
https://plantuml.com/en/text-encoding
2. https://github.com/plantuml/plantuml/issues/117#issuecomment-623545016
3. https://forum.plantuml.net/11432/the-plugin-you-are-using-seems-generate-private-gitlab-server?show=11433#a11433
4. https://github.com/bauglir/render-plantuml/commit/f69ff030a1a7e8405667fc84fec5aadaa4d0f61e
 