### PR TITLE
More suitable message in deprecation warning.

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -750,7 +750,7 @@ Shortcuts             Command Name
   "Warns the user about the deprecation of the `puml-mode' project."
   (if (and plantuml-suppress-deprecation-warning
            (featurep 'puml-mode))
-      (display-warning :warning
+      (display-warning 'plantuml-mode
                        "`puml-mode' is now deprecated and no longer updated, but it's still present in your system. \
 You should move your configuration to use `plantuml-mode'. \
 See more at https://github.com/skuro/puml-mode/issues/26")))


### PR DESCRIPTION
1st parameter for `display-warning` is used as part of warning message.
https://www.gnu.org/software/emacs/manual/html_node/elisp/Warning-Basics.html#Warning-Basics says
> The first symbol should be the custom group that you use for the program’s user options. For example, byte compiler warnings use the warning type (bytecomp).

And some other packaged use their own named symbol for that.

Current plantuml-mode uses `:warning` for that,
but it may be for 3rd (and optional) parameter of `display-warning`.