### PR TITLE
Use the Emacs default tab width for plantuml-indent-level

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -143,7 +143,7 @@
   :type 'boolean
   :group 'plantuml)
 
-(defcustom plantuml-indent-level 8
+(defcustom plantuml-indent-level tab-width
   "Indentation level of PlantUML lines")
 
 (defun plantuml-jar-render-command (&rest arguments)


### PR DESCRIPTION
It might be confusing for users if plantuml uses a different tab width
then they specifed in tab-width.

FYI: `preview-txt-test` fails but it also fails on `develop`. 