### PR TITLE
Move point at most to beginning of line when indenting

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -723,8 +723,10 @@ Restore point to same position in text of the line as before indentation."
       (beginning-of-line)
       (indent-line-to (* plantuml-indent-level (plantuml-current-block-depth))))
 
-    ;; restore position in text of line
-    (goto-char (- (line-end-position) original-position-eol))))
+    ;; restore position in text of line, but not before the beginning of the
+    ;; current line
+    (goto-char (max (line-beginning-position)
+                    (- (line-end-position) original-position-eol)))))
 
 
 ;;;###autoload


### PR DESCRIPTION
When indenting a line, point is moved synchronously to keep the current position
relative to the surrounding text.  This works well when the indentation level is
increased (point is moved to the right then), but when the indentation level is
decreased (point is moved to the left), it might happen that point is moved
beyond the beginning of the current line, positioning it somewhere on the
previous line or even before that.  This commit fixes this undesired behavior by
never moving point before the beginning of the current line.