### PR TITLE
Updates plantuml-default-exec-mode documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ When in the `plantuml-mode` buffer you can then hit again `C-'` to return to the
 
 **EXPERIMENTAL**
 
-As of `v1.3.0` support is added for switching execution mode. The following two modes are available:
+As of `v1.3.0` support is added for switching execution mode. The following three modes are available:
 
-- `jar` (default) to run PlantUML as a local JAR file. This is the traditional system used by `plantuml-mode`
-- `server` (experimental) to let an instance of [`plantuml-server`](https://github.com/plantuml/plantuml-server) render the preview
+- `jar` (traditional) to run PlantUML as a local JAR file. This is the traditional system used by `plantuml-mode`
+- `server` (default) to let an instance of [`plantuml-server`](https://github.com/plantuml/plantuml-server) render the preview
 - `executable` to run PlantUML as a local executable file. This is useful if your package manager provides a executable for PlantUML.
 
 You can customize `plantuml-default-exec-mode` or run `plantuml-set-exec-mode` from a `plantuml-mode` buffer to switch modes.


### PR DESCRIPTION
Server support defined in plantuml-default-exec-mode is explained as experimental.

However it is the default in its declaration:

  (defcustom plantuml-default-exec-mode 'server

Therefore document it as the default.

Also note that there are 3 modes instead of 2 now.