### PR TITLE
Reuse the old preview buffer/window such that display-buffer behaves

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -483,10 +483,10 @@ Put the result into buffer BUF, selecting the window according to PREFIX:
 (defun plantuml-preview-string (prefix string)
   "Preview diagram from PlantUML sources (as STRING), using prefix (as PREFIX)
 to choose where to display it."
-  (let ((b (get-buffer plantuml-preview-buffer)))
-    (when b
-      (with-current-buffer b
-        (erase-buffer))))
+  (when-let ((b (get-buffer plantuml-preview-buffer))
+             (inhibit-read-only t))
+    (with-current-buffer b
+      (erase-buffer)))
 
   (let* ((imagep (and (display-images-p)
                       (plantuml-is-image-output-p)))

--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -404,7 +404,8 @@ Window is selected according to PREFIX:
     (when imagep
       (with-current-buffer buf
         (image-mode)
-        (set-buffer-multibyte t)))))
+        (set-buffer-multibyte t)))
+    (set-window-point (get-buffer-window buf 'visible) (point-min))))
 
 (defun plantuml-jar-preview-string (prefix string buf)
   "Preview the diagram from STRING by running the PlantUML JAR.
@@ -484,7 +485,8 @@ Put the result into buffer BUF, selecting the window according to PREFIX:
 to choose where to display it."
   (let ((b (get-buffer plantuml-preview-buffer)))
     (when b
-      (kill-buffer b)))
+      (with-current-buffer b
+        (erase-buffer))))
 
   (let* ((imagep (and (display-images-p)
                       (plantuml-is-image-output-p)))


### PR DESCRIPTION
Before, the buffer is killed and then recreated. This causes wrong behavior for display-buffer when display-buffer-reuse-window and display-buffer-same-window is used: the first one fails so the same window is used where the diagram source is situated.

Instead, reuse the buffer and its window, so don't kill the buffer, erase it instead.