### PR TITLE
Explicitly set buffer-file-coding of the preview buffer to no-conversion

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -491,6 +491,9 @@ to choose where to display it."
          (buf (get-buffer-create plantuml-preview-buffer))
          (coding-system-for-read (and imagep 'binary))
          (coding-system-for-write (and imagep 'binary)))
+    (when imagep
+      (with-current-buffer buf
+        (set-buffer-file-coding-system 'no-conversion)))
     (plantuml-exec-mode-preview-string prefix (plantuml-get-exec-mode) string buf)))
 
 (defun plantuml-preview-buffer (prefix)


### PR DESCRIPTION
In Emacs 29, If default buffer-file-coding is utf-8, and plantuml output type is "png", when doing "plantuml-preview-buffer", it will pop up error that it can't detect image type from the buffer.

This fixing is explicitly set the previous buffer's buffer-file-coding to "no-conversion" to avoid such issue.