### PR TITLE
fix plantuml server url encode

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -426,8 +426,9 @@ Put the result into buffer BUF.  Window is selected according to PREFIX:
   "Encode the string STRING into a URL suitable for PlantUML server interactions."
   (let* ((coding-system (or buffer-file-coding-system
                             "utf8"))
-         (encoded-string (base64-encode-string (encode-coding-string string coding-system) t)))
-    (concat plantuml-server-url "/" plantuml-output-type "/-base64-" encoded-string)))
+	 (str (encode-coding-string string coding-system))
+         (encoded-string (mapconcat (lambda(x)(format "%02X" x)) str ) ))
+    (concat plantuml-server-url "/" plantuml-output-type "/~h" encoded-string)))
 
 (defun plantuml-server-preview-string (prefix string buf)
   "Preview the diagram from STRING as rendered by the PlantUML server.


### PR DESCRIPTION
as [plantuml](https://plantuml.com/text-encoding) says only support hex and deflate algorithm encoded format.
