### PR TITLE
Reuse the preview buffer

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -484,7 +484,9 @@ Put the result into buffer BUF, selecting the window according to PREFIX:
 to choose where to display it."
   (let ((b (get-buffer plantuml-preview-buffer)))
     (when b
-      (kill-buffer b)))
+      (with-current-buffer b
+        (let ((inhibit-read-only t))
+          (erase-buffer)))))
 
   (let* ((imagep (and (display-images-p)
                       (plantuml-is-image-output-p)))


### PR DESCRIPTION
This keeps the window configuration more stable (when killing and regenerating, the preview can end up in a different window if you have >2).

I don't know if there is other buffer-local information in the preview buffer that needs to be deleted (apart from what `erase-buffer` does); but it seems to work fine in my testing.