### PR TITLE
Disable line breaks in base64 encoded strings

### DIFF
--- a/plantuml-mode.el
+++ b/plantuml-mode.el
@@ -495,7 +495,7 @@ Put the result into buffer BUF.  Window is selected according to PREFIX:
 (defun plantuml-server-deflate-encode-url (string)
   "DEFLATE-encode STRING into a URL suitable for PlantUML server interactions."
   (let* ((compressed-bytes (deflate-zlib-compress string 'dynamic))
-         (base64-encoded (base64-encode-string (apply #'unibyte-string compressed-bytes))))
+         (base64-encoded (base64-encode-string (apply #'unibyte-string compressed-bytes) t)))
     (with-temp-buffer
       (insert base64-encoded)
       (translate-region (point-min) (point-max) plantuml-server-base64-char-table)

--- a/test/plantuml-server-test.el
+++ b/test/plantuml-server-test.el
@@ -71,6 +71,28 @@
                             "     └─┘          └─┘\n")
                     (buffer-string))))))
 
+(ert-deftest plantuml-server-test/deflate-encoding/no-injected-line-breaks ()
+  "Test DEFLATE encoding does not inject line breaks when encoding to base64."
+  :tags '(server)
+
+  (plantuml-test-server
+   (lambda ()
+     (setq-local plantuml-server-encode-mode 'deflate)
+     (plantuml-server-preview-string 0 "@startuml\nBob -> Alice : foo\nAlice -> Bob : bar\n@enduml" (current-buffer))
+
+     (should (equal (concat "     ┌───┐          ┌─────┐\n"
+                            "     │Bob│          │Alice│\n"
+                            "     └─┬─┘          └──┬──┘\n"
+                            "       │     foo       │   \n"
+                            "       │──────────────>│   \n"
+                            "       │               │   \n"
+                            "       │     bar       │   \n"
+                            "       │<──────────────│   \n"
+                            "     ┌─┴─┐          ┌──┴──┐\n"
+                            "     │Bob│          │Alice│\n"
+                            "     └───┘          └─────┘\n")
+                    (buffer-string))))))
+
 
 
 (provide 'plantuml-server-test)


### PR DESCRIPTION
Turns out that `(base64-encode-string STRING)` breaks long lines with newlines by default. The resulting string is invalid and ignored by the diagram generation code (tested in `'server` mode using the official Docker image).
According to the function's documentation, you have to set the second optional argument `NO-LINE-BREAK` to prevent that.